### PR TITLE
Update aruba.py

### DIFF
--- a/projects/core/uoft_core/aruba.py
+++ b/projects/core/uoft_core/aruba.py
@@ -108,7 +108,7 @@ class AP_Provisioning:
             json={
                 "name": mac_address,
                 "certtype": "factory-cert",
-                "act": "approved-ready-for-cert",
+                "act": "certified-factory-cert",
             },
         )
         assert (


### PR DESCRIPTION
Correction to cert "act" field in wdb_cpsec_modify_mac_factory_approved.  This was mistakenly "approved-ready-for-cert" instead of "certified-factory-cert" which caused CPSEC entries to become unapproved after a short time.