### PR TITLE
Improvements to nautobot, aruba, core, and dev tooling

### DIFF
--- a/projects/aruba/uoft_aruba/api.py
+++ b/projects/aruba/uoft_aruba/api.py
@@ -9,7 +9,9 @@ class ArubaRESTAPIError(Exception):
 
 
 class ArubaRESTAPIClient:
-    def __init__(self, host, username, password, default_config_path = "/mm", ssl_verify = False) -> None:
+    def __init__(
+        self, host, username, password, default_config_path="/mm", ssl_verify=False
+    ) -> None:
         self.host = host
         self.auth = dict(username=username, password=password)
         self.session = Session()
@@ -155,7 +157,7 @@ class ArubaRESTAPIClient:
                     data={
                         "name": mac_address,
                         "ap_group": ap_group,
-                        "ap_name": ap_name
+                        "ap_name": ap_name,
                     },
                 )
 
@@ -185,8 +187,10 @@ class ArubaRESTAPIClient:
                 )
 
             @staticmethod
-            def get_cpsec_whitelist():
-                return self.showcommand("show whitelist-db cpsec")['Control-Plane Security Allowlist-entry Details']
+            def get_cpsec_allowlist():
+                return self.showcommand("show whitelist-db cpsec")[
+                    "Control-Plane Security Allowlist-entry Details"
+                ]
 
         return AP_Provisioning
 
@@ -218,9 +222,7 @@ class ArubaRESTAPIClient:
 
             @staticmethod
             def get_ap_groups():
-                res = self.session.get(
-                    self.endpoint.object + "/ap_group"
-                ).json()
+                res = self.session.get(self.endpoint.object + "/ap_group").json()
                 return res["_data"]["ap_group"]
 
             @staticmethod

--- a/projects/aruba/uoft_aruba/batch.py
+++ b/projects/aruba/uoft_aruba/batch.py
@@ -112,6 +112,18 @@ class Provisioner:
             self.mobility_master.ap_provisioning.wdb_cpsec_delete_mac(
                 old_ap["MAC-Address"]
             )
+            try:
+                del self.existing_aps_by_mac
+            except AttributeError:
+                pass
+            try:
+                del self.existing_aps_by_name
+            except AttributeError:
+                pass
+            try:
+                del self.existing_aps_in_allowlist
+            except AttributeError:
+                pass
         self.console.print(msg)
 
     def provision_ap(self, name, group, mac_address):

--- a/projects/aruba/uoft_aruba/batch.py
+++ b/projects/aruba/uoft_aruba/batch.py
@@ -1,0 +1,249 @@
+import re
+from . import Settings
+from typing import Iterable, Sequence, Literal
+from functools import cached_property
+
+from uoft_core.types import BaseModel
+from pydantic import validator
+
+
+class AP(BaseModel):
+    name: str
+    group: str
+    mac_address: str
+
+    @validator("mac_address")
+    def validate_mac_address(cls, v):
+        mac_address_validate_pattern = re.compile(
+            r"^(?:[0-9A-Fa-f]{2}[:\-\.]?){5}(?:[0-9A-Fa-f]{2})$"
+        )
+        match = re.match(mac_address_validate_pattern, v)
+        if match:
+            v = re.sub("[:.-]", "", v)
+            v = ":".join([v[i : i + 2] for i in range(0, 12, 2)])
+            v = v.lower()
+            return v
+        else:
+            raise ValueError("Invalid MAC Address")
+
+    @validator("name", "group")
+    def validate_len(cls, v):
+        if len(v) > 75:
+            raise ValueError("too long, must be 75 characters or less")
+        return v
+
+
+class ProvisionError(Exception):
+    def __init__(self, *args: object, ap: AP) -> None:
+        self.ap = ap
+        super().__init__(*args)
+
+
+class InvalidField(ProvisionError):
+    def __init__(self, *args: object, field: str, ap: AP) -> None:
+        self.field = field
+        super().__init__(*args, ap=ap)
+
+
+class AlreadyExists(ProvisionError):
+    def __init__(self, *args: object, ap: AP, old_ap: dict[str, str]) -> None:
+        self.old_ap = old_ap
+        super().__init__(*args, ap=ap)
+
+
+class Provisioner:
+    def __init__(
+        self,
+        on_error: Literal["skip", "stop", "force"] = "skip",
+        dry_run: bool = False,
+    ) -> None:
+        self.settings = Settings.from_cache()
+        self.error_policy = on_error
+        self.dry_run = dry_run
+        self._controller = None
+        self._mobility_master = None
+
+    def provision_aps(
+        self,
+        inputs: Sequence[tuple[str, str, str]],
+    ):
+        return list(self.provision_aps_iter(inputs))
+
+    def provision_aps_iter(
+        self,
+        inputs: Iterable[tuple[str, str, str]],
+    ):
+        for ap in inputs:
+            try:
+                yield self.provision_ap(*ap)
+            except InvalidField as e:
+                if self.error_policy == "skip":
+                    self.console.print(
+                        f"[red]ERROR[/] {e.args[0]} [red]SKIPPING[/] {e.ap}"
+                    )
+                    yield e
+                else:
+                    raise e
+            except AlreadyExists as e:
+                if 'already correctly provisioned' in e.args[0]:
+                    self.console.print(
+                        f"AP_NAME {e.ap.name} already correctly provisioned. [green]SKIPPING[/]"
+                    )
+                    yield e.ap
+                elif self.error_policy == "force":
+                    yield self.force_provision_ap(e.ap, e.old_ap)
+                elif self.error_policy == "skip":
+                    self.console.print(
+                        f"[red]ERROR[/] {e.args[0]} [red]SKIPPING[/] {e.ap}"
+                    )
+                    yield e
+                else:
+                    raise e
+
+    def force_provision_ap(self, ap: AP, old_ap: dict[str, str]):
+        self.delete_existing_ap(old_ap)
+        return self.provision_ap(ap.name, group=ap.group, mac_address=ap.mac_address)
+
+    def delete_existing_ap(self, old_ap):
+        msg = f"Deleted existing AP_NAME {old_ap['AP-Name']} / {old_ap['MAC-Address']} from whitelist...[green]GOOD[/]"
+        if self.dry_run:
+            msg = "Would have " + msg
+        else:
+            self.mobility_master.ap_provisioning.wdb_cpsec_delete_mac(
+                old_ap['MAC-Address']
+            )
+        self.console.print(msg)
+
+    def provision_ap(self, name, group, mac_address):
+        self.console.print(
+            f"Provisioning {name} with MAC {mac_address} in group {group}..."
+        )
+
+        # instantiating the AP will validate the fields automatically. Thanks Pydantic!
+        ap = AP(mac_address=mac_address, group=group, name=name)
+        self.console.print("Verifying input parameters...[green]GOOD[/]")
+
+        self._validate_group(ap)
+
+        self._validate_name(ap)
+
+        self._validate_mac(ap)
+
+        msg = f"Added new AP_NAME {ap.name} / {ap.mac_address} to whitelist...[green]GOOD[/]"
+        if self.dry_run:
+            msg = "Would have " + msg
+        else:
+            self.mobility_master.ap_provisioning.wdb_cpsec_add_mac(
+                ap.mac_address, ap.group, ap.name
+            )
+        self.console.print(msg)
+
+        msg = f"Modified CPSEC entry for {ap.name} / {ap.mac_address} to factory_approved...[green]GOOD[/]"
+        if self.dry_run:
+            msg = "Would have " + msg
+        else:
+            self.mobility_master.ap_provisioning.wdb_cpsec_modify_mac_factory_approved(
+                ap.mac_address
+            )
+        self.console.print(msg)
+
+        return ap
+
+    def __del__(self):
+        # Make sure we log out of the controllers when we're done
+        if self._controller is not None:
+            self._controller.logout()
+        if self._mobility_master is not None:
+            self._mobility_master.logout()
+
+    @property
+    def controller(self):
+        if self._controller is None:
+            # we only need API access to a controller to collect the list of AP groups
+            # it doesn't really matter which controller we use, so we just pick the first one
+            self._controller = self.settings.md_api_connections[0]
+            self._controller.login()
+        return self._controller
+
+    @property
+    def mobility_master(self):
+        if self._mobility_master is None:
+            self._mobility_master = self.settings.mm_api_connection
+            self._mobility_master.login()
+        return self._mobility_master
+
+    def _validate_group(self, ap: AP):
+        if ap.group not in self.all_groups_by_name:
+            msg = f"AP_GROUP {ap.group} does not exist on controller."
+            raise InvalidField(msg, field="ap_group", ap=ap)
+        self.console.print(
+            f"Verifying AP_GROUP {ap.group} exists on controller...[green]GOOD[/]"
+        )
+
+    def _validate_name(self, ap: AP):
+        if ap.name in self.existing_aps_by_name:
+            existing_ap = self.existing_aps_by_name[ap.name]
+            if existing_ap["MAC-Address"] == ap.mac_address:
+                if existing_ap["AP-Group"] == ap.group:
+                    raise AlreadyExists(
+                        f"AP_NAME {ap.name} is already correctly provisioned.",
+                        ap=ap,
+                        old_ap=existing_ap,
+                    )
+                else:
+                    msg = f"AP_NAME {ap.name} already exists on controller in group {existing_ap['AP-Group']}."
+                    raise AlreadyExists(msg, ap=ap, old_ap=existing_ap)
+            else:
+                msg = f"AP_NAME {ap.name} already exists on controller with MAC {existing_ap['MAC-Address']}."
+                raise AlreadyExists(msg, ap=ap, old_ap=existing_ap)
+        self.console.print(
+            f"Verifying AP_NAME {ap.name} is not in use...[green]GOOD[/]"
+        )
+
+    def _validate_mac(self, ap: AP):
+        if ap.mac_address in self.existing_aps_by_mac:
+            existing_ap = self.existing_aps_by_mac[ap.mac_address]
+            if existing_ap["AP-Name"] == ap.name:
+                if existing_ap["AP-Group"] == ap.group:
+                    raise AlreadyExists(
+                        f"MAC {ap.mac_address} is already correctly provisioned.",
+                        ap=ap,
+                        old_ap=existing_ap,
+                    )
+                else:
+                    msg = f"MAC {ap.mac_address} already exists on controller in group {existing_ap['AP-Group']}."
+                    raise AlreadyExists(msg, ap=ap, old_ap=existing_ap)
+            msg = f"MAC {ap.mac_address} already exists on controller with AP_NAME {existing_ap['AP-Name']}."
+            raise AlreadyExists(msg, ap=ap, old_ap=existing_ap)
+        self.console.print(
+            f"Verifying MAC {ap.mac_address} is not in use...[green]GOOD[/]"
+        )
+
+    @property
+    def console(self):
+        return self.settings.util.console
+
+    @cached_property
+    def all_groups_by_name(self) -> set[str]:
+        return {
+            g["profile-name"].rpartition("'")[2]
+            for g in self.controller.wlan.get_ap_groups()
+        }
+
+    @cached_property
+    def existing_aps_in_whitelist(self):
+        return self.mobility_master.ap_provisioning.get_cpsec_whitelist()
+
+    @cached_property
+    def existing_aps_by_name(self):
+        return {
+            ap["AP-Name"]: ap for ap in self.existing_aps_in_whitelist if ap["AP-Name"]
+        }
+
+    @cached_property
+    def existing_aps_by_mac(self):
+        return {
+            ap["MAC-Address"]: ap
+            for ap in self.existing_aps_in_whitelist
+            if ap["MAC-Address"]
+        }

--- a/projects/aruba/uoft_aruba/batch.py
+++ b/projects/aruba/uoft_aruba/batch.py
@@ -85,7 +85,7 @@ class Provisioner:
                 else:
                     raise e
             except AlreadyExists as e:
-                if 'already correctly provisioned' in e.args[0]:
+                if "already correctly provisioned" in e.args[0]:
                     self.console.print(
                         f"AP_NAME {e.ap.name} already correctly provisioned. [green]SKIPPING[/]"
                     )
@@ -105,12 +105,12 @@ class Provisioner:
         return self.provision_ap(ap.name, group=ap.group, mac_address=ap.mac_address)
 
     def delete_existing_ap(self, old_ap):
-        msg = f"Deleted existing AP_NAME {old_ap['AP-Name']} / {old_ap['MAC-Address']} from whitelist...[green]GOOD[/]"
+        msg = f"Deleted existing AP_NAME {old_ap['AP-Name']} / {old_ap['MAC-Address']} from allowlist...[green]GOOD[/]"
         if self.dry_run:
             msg = "Would have " + msg
         else:
             self.mobility_master.ap_provisioning.wdb_cpsec_delete_mac(
-                old_ap['MAC-Address']
+                old_ap["MAC-Address"]
             )
         self.console.print(msg)
 
@@ -129,7 +129,7 @@ class Provisioner:
 
         self._validate_mac(ap)
 
-        msg = f"Added new AP_NAME {ap.name} / {ap.mac_address} to whitelist...[green]GOOD[/]"
+        msg = f"Added new AP_NAME {ap.name} / {ap.mac_address} to allowlist...[green]GOOD[/]"
         if self.dry_run:
             msg = "Would have " + msg
         else:
@@ -231,19 +231,19 @@ class Provisioner:
         }
 
     @cached_property
-    def existing_aps_in_whitelist(self):
-        return self.mobility_master.ap_provisioning.get_cpsec_whitelist()
+    def existing_aps_in_allowlist(self):
+        return self.mobility_master.ap_provisioning.get_cpsec_allowlist()
 
     @cached_property
     def existing_aps_by_name(self):
         return {
-            ap["AP-Name"]: ap for ap in self.existing_aps_in_whitelist if ap["AP-Name"]
+            ap["AP-Name"]: ap for ap in self.existing_aps_in_allowlist if ap["AP-Name"]
         }
 
     @cached_property
     def existing_aps_by_mac(self):
         return {
             ap["MAC-Address"]: ap
-            for ap in self.existing_aps_in_whitelist
+            for ap in self.existing_aps_in_allowlist
             if ap["MAC-Address"]
         }

--- a/projects/aruba/uoft_aruba/cli.py
+++ b/projects/aruba/uoft_aruba/cli.py
@@ -1,4 +1,4 @@
-from .cli_commands import cpsec_whitelist, station_blocklist
+from .cli_commands import cpsec_allowlist, station_blocklist
 import typer
 
 from . import Settings
@@ -10,7 +10,8 @@ app = typer.Typer(
     no_args_is_help=True,
     help=__doc__,  # Use this module's docstring as the main program help text
 )
-app.add_typer(cpsec_whitelist.run, name="cpsec-whitelist")
+app.add_typer(cpsec_allowlist.run, name="cpsec-allowlist")
+app.add_typer(cpsec_allowlist.run, name="cpsec-whitelist", deprecated=True)
 app.add_typer(station_blocklist.app, name="station-blocklist")
 app.add_typer(station_blocklist.app, name="station-blacklist", deprecated=True)
 
@@ -31,8 +32,8 @@ def deprecated():
         to = "uoft-aruba"
         cmd = app
     elif (from_ := "Aruba_Provision_CPSEC_Whitelist") in cmdline:
-        to = "uoft-aruba cpsec-whitelist"
-        cmd = cpsec_whitelist.run
+        to = "uoft-aruba cpsec-allowlist"
+        cmd = cpsec_allowlist.run
     else:
         raise ValueError(f"command {cmdline} is not deprecated")
 

--- a/projects/aruba/uoft_aruba/cli_commands/cpsec_allowlist.py
+++ b/projects/aruba/uoft_aruba/cli_commands/cpsec_allowlist.py
@@ -1,5 +1,5 @@
 """
-Welcome to the Aruba CPSEC Whitelist Provisioning Tool.
+Welcome to the Aruba CPSEC Allowlist Provisioning Tool.
 
 The Aruba wireless system utilizes the 'Control Plane Security' (CPSEC) 'Whitelist Database' (WDB) 
 to authorize and provision WAPs onto the Aruba Wireless Platform. 
@@ -21,7 +21,7 @@ run = typer.Typer(  # If run as main create a 'typer.Typer' app instance to run 
     context_settings={"max_content_width": 120, "help_option_names": ["-h", "--help"]},
     no_args_is_help=True,
     help=__doc__,  # Use this module's docstring as the main program help text
-    short_help="Aruba CPSEC Whitelist Provisioning Tool",
+    short_help="Aruba CPSEC Allowlist Provisioning Tool",
 )
 
 

--- a/projects/aruba/uoft_aruba/cli_commands/cpsec_whitelist.py
+++ b/projects/aruba/uoft_aruba/cli_commands/cpsec_whitelist.py
@@ -12,43 +12,40 @@ as well as modifying their certs to 'factory-approved' so the registrations do n
 
 import typer
 import sys
-import re
-from uoft_aruba.api import ArubaRESTAPIClient, ArubaRESTAPIError
+import csv
+import io
 from pathlib import Path
-from .. import settings
-
-InputTable = list[tuple[str, str, str]]
-
+from .. import Settings, batch
 
 run = typer.Typer(  # If run as main create a 'typer.Typer' app instance to run the program within.
     context_settings={"max_content_width": 120, "help_option_names": ["-h", "--help"]},
     no_args_is_help=True,
     help=__doc__,  # Use this module's docstring as the main program help text
     short_help="Aruba CPSEC Whitelist Provisioning Tool",
-    add_completion=False,
 )
 
 
 @run.command()
-def Get_AP_Groups(  # Create the 'get-ap-groups' command within typer.
-    debug: bool = typer.Option(False, help="Turn on debug logging"),
-):
+def get_ap_groups():  # Create the 'get-ap-groups' command within typer.
     "Returns a list of valid AP_GROUPs and exits."
-    s = settings()
+    s = Settings.from_cache()
     with s.mm_api_connection as host:
         raw_controller_ap_groups = host.wlan.get_ap_groups()
         controller_ap_groups = []
         for raw_controller_ap_group in raw_controller_ap_groups:
-            controller_ap_groups.append(raw_controller_ap_group["profile-name"].rpartition("'")[2])
-        print("Below you will find a list of valid AP_GROUPs to use in your input:")
+            controller_ap_groups.append(
+                raw_controller_ap_group["profile-name"].rpartition("'")[2]
+            )
+        s.util.console.print(
+            "Below you will find a list of valid AP_GROUPs to use in your input:"
+        )
         print(*controller_ap_groups, sep="\n")
 
 
 @run.command(  # Create the 'from-file' subcommand within 'provision'.
-    no_args_is_help=True,
     short_help="Provisions a CSV list of MAC_ADDRESS,AP_GROUP,AP_NAME's, one per line.",
 )
-def Provision(
+def provision(
     filename: Path = typer.Argument(
         ...,
         exists=True,
@@ -74,127 +71,35 @@ def Provision(
     00:01:10:12:02:21,-CC Lab,test_ap_name_18\n
     00:01:02:12:02:21,-CC Lab,test_ap_name_19
     """
+    s = Settings.from_cache()
     if filename.name == "-":
-        print(
-            """Please enter AP details to be provisioned, one per line. Press CTRL+D when complete.\n
-              MAC_ADDRESS,AP_GROUP,AP_NAME
-              MAC_ADDRESS,AP_GROUP,AP_NAME"""
-        )
-        file = sys.stdin.readlines()
+        if sys.stdin.isatty():
+            s.util.console.print(
+                """Please enter AP details to be provisioned, one per line. Press CTRL+D when complete.\nMAC_ADDRESS,AP_GROUP,AP_NAME"""
+            )
+        file = io.StringIO(sys.stdin.read())
+
     else:
-        file = filename.open().readlines()
-    input_WAPs = Read_From_File(file)
-    Verify_And_Create(input_WAPs)
+        file = filename.open()
 
+    csv_format = csv.Sniffer().sniff(file.read(1024)) or csv.excel
+    file.seek(0)
 
-def Read_From_File(file: list[str]) -> InputTable:
-    "Reads a CSV list of 'MAC_ADDRESS,AP_GROUP,AP_NAME's, one per line."
-    response = []
-    for line in file:
-        items = line.split(",")
-        # confirm we only have 3 fields in CSV and split into list 'items'
-        assert len(items) == 3, f"Error in input {line} has more than three fields."
-        response.append(tuple(items))
-    return response
-
-
-def Verify_And_Create(input_table: InputTable):
-    "Verifies input data for script, and then creates entries in CPSEC Whitelist."
-    outer_lambda = lambda row: tuple(map(lambda item: item[:75], row))
-    input_table = list(map(outer_lambda, input_table))
-    # Lambda prevent input overflow.
-    s = settings()
-    # All passwords are stored in a gpg encrypted file and accessed through pass.  No passwords are EVER in scripts.
-    with s.md_api_connections[0] as host1, s.mm_api_connection as host2:
-        Check_Input_Groups(host1, input_table)  # Confirm input AP_GROUPs exist on MD
-        Check_Input_Names_Macs(host2, input_table)  # Confirm mac format / names or macs not already in use on MM.
-        Create_Whitelist_Entry_CPSEC_And_Approve(host2, input_table)
-
-
-def Check_Input_Groups(host: ArubaRESTAPIClient, input_table: InputTable):
-    "Verifies input AP_GROUPs data for script, returns an error if an input AP_GROUP does not exist on Managed Device."
-    raw_controller_ap_groups = host.wlan.get_ap_groups()
-    controller_ap_groups = []
-    group_assertion_list = []
-    for raw_controller_ap_group in raw_controller_ap_groups:
-        controller_ap_groups.append(raw_controller_ap_group["profile-name"].rpartition("'")[2])
-    input_ap_groups = [line[1] for line in input_table]
-    for input_ap_group in input_ap_groups:
-        if input_ap_group not in controller_ap_groups:
-            group_assertion_list.append(input_ap_group)
-        else:
-            print(f"Verifying Input AP_GROUP '{input_ap_group}' is valid...GOOD")
-    if len(group_assertion_list) != 0:
-        raise Exception(
-            f"The following AP_GROUP(s) are -not- configured on the controller!\n \
-            '{group_assertion_list}'\nConfirm input!  Run --help for help."
-        )
-
-
-def Check_Input_Names_Macs(host: ArubaRESTAPIClient, input_table: InputTable):
-    """
-    Verifies input AP_NAMEs and MAC_ADDRESSes data for script,
-    returns an error if an input AP_NAME or MAC_ADDRESS already exists in CPSEC Whitelist.
-    """
-    raw_controller_ap_names_macs = host.showcommand("show whitelist-db cpsec")[
-        "Control-Plane Security Allowlist-entry Details"
+    reader = csv.reader(file, csv_format)
+    aps_list = [
+        (ap_name, ap_group, mac_address)
+        for mac_address, ap_group, ap_name, *_ in reader
     ]
-    controller_ap_names = []
-    controller_ap_macs = []
-    name_assertion_list = []
-    mac_assertion_list = []
-    for raw_ap_name in raw_controller_ap_names_macs:
-        controller_ap_names.append(raw_ap_name["AP-Name"])
-    input_ap_names = [line[2] for line in input_table]
-    for input_ap_name in input_ap_names:
-        if input_ap_name in controller_ap_names:
-            name_assertion_list.append(input_ap_name)
-        else:
-            print(f"Verifying Input AP_NAME {input_ap_name} is not in use...GOOD")
+    results = batch.Provisioner(dry_run=True).provision_aps(aps_list)
+    failed_aps = [ap for ap in results if isinstance(ap, Exception)]
 
-    if len(name_assertion_list) != 0:
-        raise Exception(
-            f"The following AP_NAME(s) are already in use on the controller!\n \
-            '{name_assertion_list}'\nConfirm input!  Run --help for help."
-        )
-    for raw_ap_mac in raw_controller_ap_names_macs:
-        controller_ap_macs.append(raw_ap_mac["MAC-Address"])
-    input_mac_addresses = [line[0] for line in input_table]
-    for input_ap_mac in input_mac_addresses:
-        mac_address_validate_pattern = "^(?:[0-9A-Fa-f]{2}[:-]){5}(?:[0-9A-Fa-f]{2})$"
-        match = re.match(mac_address_validate_pattern, input_ap_mac)
-        if match:
-            print(f"Verifying format of input MAC_ADDRESS {input_ap_mac} ...GOOD")
-        else:
-            raise Exception(f"Mac address format incorrect for {input_ap_mac}")
-        if input_ap_mac in controller_ap_macs:
-            mac_assertion_list.append(input_ap_mac)
-    if len(mac_assertion_list) != 0:
-        raise Exception(
-            f"The following MAC_ADDRESS(es) are already in use on the controller!\n \
-            '{mac_assertion_list}'\nConfirm input!  Run --help for help."
-        )
+    if failed_aps:
+        s.util.console.print("The following APs failed to provision:\nMAC_ADDRESS,AP_GROUP,AP_NAME,REASON")
+        for ap_error in failed_aps:
+            s.util.console.print(
+                f"{ap_error.ap.mac_address},{ap_error.ap.group},{ap_error.ap.name},{ap_error.args[0]}"
+            )
 
-
-def Create_Whitelist_Entry_CPSEC_And_Approve(host: ArubaRESTAPIClient, input_table: InputTable):
-    "Creates the CPSEC Whitelist entries, and then modifies this certificate types to 'factory-approved'."
-    for line in input_table:
-        input_mac_address, input_ap_group, input_ap_name = line
-        input_ap_name = input_ap_name.rstrip("\n")
-        try:
-            host.ap_provisioning.wdb_cpsec_add_mac(input_mac_address, input_ap_group, input_ap_name)
-            print(
-                f"Added new CPSEC whitelist entry for {input_ap_name} / {input_mac_address}"
-            )  # Create a CPSEC whitelist entry, for each WAP in the supplied file.
-            host.ap_provisioning.wdb_cpsec_modify_mac_factory_approved(input_mac_address)
-            # Modify a CPSEC whitelist entry to have a permanent factory-approved certifiacte, for each WAP in the supplied file.
-            print(f"Modified CPSEC entry for {input_ap_name} / {input_mac_address} to factory_approved")
-
-        except ArubaRESTAPIError as e:
-            if e.data:
-                msg = e.data.get("_global_result", {}).get("status_str")
-                if msg and "already exists" in msg:
-                    print(f"Warning: CPSEC entry for {input_ap_name} / {input_mac_address} already exists, skipping")
 
 def _debug():
     "Debugging function, only used in active debugging sessions."

--- a/projects/aruba/uoft_aruba/tests/end_to_end_tests.py
+++ b/projects/aruba/uoft_aruba/tests/end_to_end_tests.py
@@ -1,6 +1,8 @@
 from uoft_aruba import Settings, ArubaRESTAPIClient
+from .. import batch
 
 import pytest
+
 
 def _get_blacklist(*controllers):
     blacklist = []
@@ -8,6 +10,7 @@ def _get_blacklist(*controllers):
         controller: ArubaRESTAPIClient
         blacklist += [x["STA"] for x in controller.wlan.get_ap_client_blacklist()]
     return set(blacklist)
+
 
 @pytest.mark.end_to_end
 class APITests:
@@ -46,7 +49,9 @@ class APITests:
             md2.login()
 
             group_name = mm.wlan.get_ap_groups()[0]["profile-name"]
-            mm.ap_provisioning.wdb_cpsec_add_mac("11:11:11:11:11:11", group_name, "testap")
+            mm.ap_provisioning.wdb_cpsec_add_mac(
+                "11:11:11:11:11:11", group_name, "testap"
+            )
             whitelist = mm.ap_provisioning.get_cpsec_whitelist()
             whitelist = {x["MAC-Address"]: x for x in whitelist}
             assert "11:11:11:11:11:11" in whitelist
@@ -61,3 +66,87 @@ class APITests:
             mm.logout()
             md1.logout()
             md2.logout()
+
+
+@pytest.mark.end_to_end
+def test_batch_provisioner():
+    p = batch.Provisioner(dry_run=True)
+    groups = list(p.all_groups_by_name)
+    valid_group = groups[0]
+    other_group = groups[1]
+    ap_invalid_group = "invalid_group"
+
+    ap_already_provisioned = "already_provisioned", valid_group, "00:1a:1e:00:00:00"
+    ap_to_provision = "to_provision", valid_group, "00:1a:1e:00:00:01"
+    ap_invalid_group = (
+        "invalid_group",
+        ap_invalid_group,
+        "00:1a:1e:00:00:02",
+    )
+    ap_other_group = (
+        "other_group",
+        other_group,
+        "00:1a:1e:00:00:03",
+    )
+    ap_mac_in_use = (
+        "mac_in_use",
+        valid_group,
+        "00:1a:1e:00:00:04",
+    )
+
+    input_list = [
+        ap_already_provisioned,
+        ap_to_provision,
+        ap_invalid_group,
+        ap_other_group,
+        ap_mac_in_use,
+    ]
+
+    # setup
+
+    # we want 'ap_already_provisioned' to already exist in the whitelist
+    # by the time we run the batch provisioner
+    p.mobility_master.ap_provisioning.wdb_cpsec_add_mac(
+        ap_name=ap_already_provisioned[0],
+        ap_group=ap_already_provisioned[1],
+        mac_address=ap_already_provisioned[2],
+    )
+
+    # we want 'ap_other_group' to already exist in the whitelist
+    # but in a different group than the one we're trying to provision it in
+    p.mobility_master.ap_provisioning.wdb_cpsec_add_mac(
+        ap_name=ap_other_group[0],
+        ap_group=valid_group,
+        mac_address=ap_other_group[2],
+    )
+
+    # we want the mac address of 'ap_mac_in_use' to already exist in the whitelist
+    # but with a different ap name than the one we're trying to provision
+    p.mobility_master.ap_provisioning.wdb_cpsec_add_mac(
+        ap_name="already_in_use",
+        ap_group=valid_group,
+        mac_address=ap_mac_in_use[2],
+    )
+
+    try:
+        res = p.provision_aps(input_list)
+    finally:
+        for *_, mac in input_list:
+            try:
+                p.mobility_master.ap_provisioning.wdb_cpsec_delete_mac(mac)
+            except Exception as e:
+                if "Entry does not exist" in e.args[0]:
+                    pass
+                else:
+                    raise e
+
+    assert len(res) == len(input_list)
+    assert isinstance(res[0], batch.AP)
+    assert isinstance(res[1], batch.AP)
+    assert isinstance(res[2], batch.InvalidField)
+    assert res[2].field == "ap_group"
+    assert "does not exist" in res[2].args[0]
+    assert isinstance(res[3], batch.AlreadyExists)
+    assert "already exists on controller in group" in res[3].args[0]
+    assert isinstance(res[4], batch.AlreadyExists)
+    assert "already exists on controller with AP_NAME" in res[4].args[0]

--- a/projects/aruba/uoft_aruba/tests/end_to_end_tests.py
+++ b/projects/aruba/uoft_aruba/tests/end_to_end_tests.py
@@ -36,7 +36,7 @@ class APITests:
             md1.logout()
             md2.logout()
 
-    def test_cpsec_whitelist(self):
+    def test_cpsec_allowlist(self):
         s = Settings.from_cache()
 
         mm = s.mm_api_connection
@@ -52,15 +52,15 @@ class APITests:
             mm.ap_provisioning.wdb_cpsec_add_mac(
                 "11:11:11:11:11:11", group_name, "testap"
             )
-            whitelist = mm.ap_provisioning.get_cpsec_whitelist()
-            whitelist = {x["MAC-Address"]: x for x in whitelist}
-            assert "11:11:11:11:11:11" in whitelist
+            allowlist = mm.ap_provisioning.get_cpsec_allowlist()
+            allowlist = {x["MAC-Address"]: x for x in allowlist}
+            assert "11:11:11:11:11:11" in allowlist
 
             mm.ap_provisioning.wdb_cpsec_delete_mac("11:11:11:11:11:11")
 
-            whitelist = mm.ap_provisioning.get_cpsec_whitelist()
-            whitelist = {x["MAC-Address"]: x for x in whitelist}
-            assert "11:11:11:11:11:11" not in whitelist
+            allowlist = mm.ap_provisioning.get_cpsec_allowlist()
+            allowlist = {x["MAC-Address"]: x for x in allowlist}
+            assert "11:11:11:11:11:11" not in allowlist
 
         finally:
             mm.logout()
@@ -104,7 +104,7 @@ def test_batch_provisioner():
 
     # setup
 
-    # we want 'ap_already_provisioned' to already exist in the whitelist
+    # we want 'ap_already_provisioned' to already exist in the allowlist
     # by the time we run the batch provisioner
     p.mobility_master.ap_provisioning.wdb_cpsec_add_mac(
         ap_name=ap_already_provisioned[0],
@@ -112,7 +112,7 @@ def test_batch_provisioner():
         mac_address=ap_already_provisioned[2],
     )
 
-    # we want 'ap_other_group' to already exist in the whitelist
+    # we want 'ap_other_group' to already exist in the allowlist
     # but in a different group than the one we're trying to provision it in
     p.mobility_master.ap_provisioning.wdb_cpsec_add_mac(
         ap_name=ap_other_group[0],
@@ -120,7 +120,7 @@ def test_batch_provisioner():
         mac_address=ap_other_group[2],
     )
 
-    # we want the mac address of 'ap_mac_in_use' to already exist in the whitelist
+    # we want the mac address of 'ap_mac_in_use' to already exist in the allowlist
     # but with a different ap name than the one we're trying to provision
     p.mobility_master.ap_provisioning.wdb_cpsec_add_mac(
         ap_name="already_in_use",

--- a/projects/bluecat/uoft_bluecat/__init__.py
+++ b/projects/bluecat/uoft_bluecat/__init__.py
@@ -1,4 +1,5 @@
-from typing import Literal
+from typing import Literal, TypedDict, Iterator
+from logging import getLogger
 
 from uoft_core import BaseSettings, Field
 from uoft_core.types import SecretStr
@@ -8,6 +9,39 @@ from uoft_core._vendor.bluecat_libraries.address_manager.constants import (
     ObjectType,
     OptionType,
 )
+
+logger = getLogger(__name__)
+
+CONTAINER_TYPES = [
+    ObjectType.IP4_BLOCK,
+    ObjectType.IP6_BLOCK,
+]
+ALL_NETWORK_TYPES = [
+    ObjectType.IP4_NETWORK,
+    ObjectType.IP6_NETWORK,
+    ObjectType.IP4_IP_GROUP,
+    *CONTAINER_TYPES,
+]
+
+ADDRESS_TYPES = [
+    ObjectType.IP4_ADDRESS,
+    ObjectType.IP6_ADDRESS,
+]
+
+
+class APIEntity(TypedDict):
+    id: int
+    name: str | None
+    type: ObjectType
+    properties: dict[str, str]
+
+
+class Network(APIEntity, total=False):
+    children: list["Network"]
+
+
+class Address(APIEntity):
+    address: str
 
 
 class API:
@@ -21,7 +55,7 @@ class API:
         """Get a configuration by name, or the first available configuration if no name is provided"""
         if name:
             return self.client.get_entity_by_name(0, name, ObjectType.CONFIGURATION)
-        return self.client.get_entities(0, ObjectType.CONFIGURATION)[0]
+        return next(self.get_entities(0, ObjectType.CONFIGURATION))
 
     def get_entities(self, parent_id, typ, start=0):
         page_size = 100
@@ -30,20 +64,67 @@ class API:
         )
         yield from entities
         if len(entities) == page_size:
+            logger.info(f"Getting more {typ} entries from {start + page_size}")
             yield from self.get_entities(parent_id, typ, start=start + page_size)
+
+    def yield_ip_object_tree(self, parent_id) -> Iterator[Network]:
+        for typ in ALL_NETWORK_TYPES:
+            for entity in self.get_entities(parent_id, typ):  # type: ignore
+                if typ in CONTAINER_TYPES:
+                    yield dict(
+                        entity, children=list(self.yield_ip_object_tree(entity["id"]))
+                    )  # type: ignore
+                yield entity  # type: ignore
+
+    def yield_ip_object_list(self, parent_id=None) -> Iterator[APIEntity]:
+        if parent_id is None:
+            parent_id = self.get_configuration()["id"]
+        for typ in ALL_NETWORK_TYPES:
+            for entity in self.get_entities(parent_id, typ):
+                yield entity  # type: ignore
+                if typ in CONTAINER_TYPES:
+                    yield from self.yield_ip_object_list(entity["id"])
+
+    def yield_ip_address_list(self, parent) -> Iterator[Address]:
+        parent_id = parent["id"]
+        if list(self.client.get_entities(parent_id, ObjectType.DHCP4_RANGE)):
+            # we don't want to sync DHCP-assigned addresses
+            return
+
+        if list(self.client.get_entities(parent_id, ObjectType.DHCP6_RANGE)):
+            # we don't want to sync DHCP-assigned addresses
+            return
+
+        for typ in ADDRESS_TYPES:
+            for entity in self.get_entities(parent_id, typ):
+                _props = parent["properties"]
+                try:
+                    _cidr = _props["CIDR"]
+                except KeyError:
+                    _cidr = _props["prefix"]
+                prefix_len = _cidr.split("/")[1]
+                address = entity["properties"]["address"]
+                cidr = f"{address}/{prefix_len}"
+                yield dict(entity, address=cidr)  # type: ignore
+
+    def yield_all_ip_addresses(self):
+        for network in self.yield_ip_object_list():
+            for address in self.yield_ip_address_list(network):
+                yield address
 
     def get_ipv4_address(
         self,
         address: str,
         configuration_id: int | None = None,
     ):
-
         if not configuration_id:
             configuration_id = self.get_configuration()["id"]
         assert configuration_id is not None
 
         return self.client.get_entity_by_cidr(
-            cidr=f"{address}/32", type=ObjectType.IP4_ADDRESS, parent_id=configuration_id
+            cidr=f"{address}/32",
+            type=ObjectType.IP4_ADDRESS,
+            parent_id=configuration_id,
         )
 
     def assign_ipv4_address(

--- a/projects/core/pyproject.toml
+++ b/projects/core/pyproject.toml
@@ -42,4 +42,5 @@ path = "pyproject.py"
 
 [tool.hatch.build]
 only-packages = true
+packages = ["uoft_core"]
 exclude = ["**/tests"]

--- a/projects/core/uoft_core/__init__.py
+++ b/projects/core/uoft_core/__init__.py
@@ -579,7 +579,6 @@ class Util:
     """
 
     app_name: str
-    dirs: PlatformDirs
     console: Console
     logging: "Util.Logging"
     config: "Util.Config"
@@ -834,7 +833,7 @@ class Util:
                 format=self.stderr_format,
             )
             options.update(kwargs)
-            logger.add(sys.stderr, **options)
+            logger.add(sys.stderr, **options)  # type: ignore
 
         def add_stderr_rich_sink(self, level="INFO", **kwargs):
             options = dict(
@@ -843,7 +842,7 @@ class Util:
                 format=self.stderr_format,
             )
             options.update(kwargs)
-            logger.add(self.parent.console.print, **options)
+            logger.add(self.parent.console.print, **options)  # type: ignore
 
         def add_json_logfile_sink(self, filename=None, level="DEBUG", **kwargs):
             filename = filename or f"{self.parent.app_name}.log"
@@ -856,7 +855,7 @@ class Util:
                 compression="zip",
             )
             options.update(kwargs)
-            logger.add(filename, **options)
+            logger.add(filename, **options)  # type: ignore
 
         def add_syslog_sink(self, level="DEBUG", syslog_address=None, **kwargs):
             if platform.system() == "Windows":
@@ -880,7 +879,7 @@ class Util:
 
             options = dict(level=level, format=self.syslog_format)
             options.update(kwargs)
-            logger.add(handler, **options)
+            logger.add(handler, **options)  # type: ignore
 
         def add_sentry_sink(self, level="ERROR", **kwargs):
             try:

--- a/projects/core/uoft_core/__init__.py
+++ b/projects/core/uoft_core/__init__.py
@@ -1171,6 +1171,7 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
 
         # If a BaseSettings subclass appears in the missing_keys list, and that field is marked prompt=False,
         # Then we should source the value from the subclass's from_cache method, and remove the subclass from the missing_keys list
+        # Additionally, if a field marked prompt=False is missing, and that field has a default value, we should use the default value
         for key in missing_keys[:]:
             field = cls.__fields__[key]
             type_ = get_origin(field.outer_type_)
@@ -1180,9 +1181,15 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
                 is_model = issubclass(type_, BaseSettings)
             except TypeError:
                 is_model = False
-            if is_model and field.field_info.extra.get("prompt", True) is False:
-                values[key] = type_.from_cache()
+            if field.field_info.extra.get("prompt", True) is False:
+
+                if is_model:
+                    values[key] = type_.from_cache()
+                
+                if field.required is False:
+                    values[key] = field.default
                 missing_keys.remove(key)
+
 
         if not missing_keys:
             # Everything's present and accounted for. nothing to do here
@@ -1190,6 +1197,7 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
 
         if not cls.Config.prompt_on_missing_values:
             # interactively prompting for values is disabled on this subclass
+            # Return values as is and let pydantic report validation errors on missing fields
             return values
 
         if not sys.stdout.isatty():

--- a/projects/core/uoft_core/_vendor/platformdirs/__init__.py
+++ b/projects/core/uoft_core/_vendor/platformdirs/__init__.py
@@ -2,41 +2,47 @@
 Utilities for determining application-specific dirs. See <https://github.com/platformdirs/platformdirs> for details and
 usage.
 """
-import importlib
 import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Type, Union
 
-if TYPE_CHECKING:
-    from typing_extensions import Literal  # pragma: no cover
-
 from .api import PlatformDirsABC
 from .version import __version__, __version_info__
 
+if TYPE_CHECKING:
+    from typing_extensions import Literal, TypeAlias  # pragma: no cover
+    from . import android, macos, unix, windows  # pragma: no cover
 
-def _set_platform_dir_class() -> Type[PlatformDirsABC]:
+    PlatformDirsType: TypeAlias = Union[
+        Type[android.Android], Type[macos.MacOS], Type[unix.Unix], Type[windows.Windows]
+    ]  # pragma: no cover
+else:
+    PlatformDirsType = Type[PlatformDirsABC]
+
+
+def _set_platform_dir_class() -> PlatformDirsType:
     if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
-        from .android import Android  # type: ignore # noqa: F401
+        from .android import Android  # type: ignore
 
         result = Android
     elif sys.platform == "win32":
-        from .windows import Windows  # type: ignore # noqa: F401
+        from .windows import Windows  # type: ignore
 
         result = Windows
     elif sys.platform == "darwin":
-        from .macos import MacOS  # type: ignore # noqa: F401
+        from .macos import MacOS  # type: ignore
 
         result = MacOS
     else:
-        from .unix import Unix  # type: ignore # noqa: F401
+        from .unix import Unix  # type: ignore
 
         result = Unix
-    result: Type[PlatformDirsABC]
+    result: PlatformDirsType
     return result
 
 
-PlatformDirs = _set_platform_dir_class()  #: Currently active platform
+PlatformDirs: PlatformDirsType = _set_platform_dir_class()  #: Currently active platform
 AppDirs = PlatformDirs  #: Backwards compatibility with appdirs
 
 

--- a/projects/nautobot/pyproject.toml
+++ b/projects/nautobot/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "uoft_ssh",
   "uoft_bluecat",
   "nautobot == 1.6.1",
+  "python-jose >= 3.0.0",
   "nautobot_ssot >= 1.3",
   "nautobot_golden_config",
   "nautobot-device-onboarding",

--- a/projects/nautobot/uoft_nautobot/auth.py
+++ b/projects/nautobot/uoft_nautobot/auth.py
@@ -1,0 +1,72 @@
+from uuid import uuid4
+from typing import Any, TYPE_CHECKING
+
+from . import Settings
+
+from django.contrib.auth.models import Group
+from social_core.pipeline.social_auth import social_user
+from social_core.backends.keycloak import KeycloakOAuth2
+from social_django.models import UserSocialAuth, DjangoStorage
+from social_django.strategy import DjangoStrategy
+from nautobot.users.models import User
+
+
+from social_django.models import UserSocialAuth, DjangoStorage
+from social_django.strategy import DjangoStrategy
+from nautobot.users.models import User
+
+if TYPE_CHECKING:
+    class Strategy(DjangoStrategy):
+        storage = DjangoStorage
+
+    class Keycloak(KeycloakOAuth2):
+        strategy: Strategy
+
+
+def get_username(
+    details: dict,
+    storage: DjangoStorage,
+    user: User | None = None,
+    *args,
+    **kwargs,
+):
+    # custom reimplementation of social_core.pipeline.user.get_username
+    # we want to be able to map usernames from keycload to existing users if they exist
+
+    if not user:
+        if details.get("username"):
+            username = details["username"]
+        else:
+            username = uuid4().hex
+    else:
+        username = storage.user.get_username(user)
+    return dict(username=username)
+
+
+def map_groups(
+    response: dict,
+    user: User,
+    *args,
+    **kwargs,):
+    s = Settings.from_cache()
+    groups_from_keycloak = response.get("userGroup", [])
+
+    # add user to groups, creating them if they don't exist
+    for group_name in s.all_groups():
+        group, _ = Group.objects.get_or_create(name=group_name)
+        if group_name in groups_from_keycloak:
+            user.groups.add(group)
+
+    # set user-level permissions based on group membership
+    print(groups_from_keycloak)
+    if s.groups_active in groups_from_keycloak:
+        print('f{user} is active')
+        user.is_active = True
+    if s.groups_staff in groups_from_keycloak:
+        print('f{user} is staff')
+        user.is_staff = True
+    if s.groups_superuser in groups_from_keycloak:
+        print('f{user} is superuser')
+        user.is_superuser = True
+    user.validated_save()
+    return {}

--- a/projects/nautobot/uoft_nautobot/datasources.py
+++ b/projects/nautobot/uoft_nautobot/datasources.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from .jinja_filters import import_repo_filters_module
-import sys
 
 from nautobot.apps.datasources import DatasourceContent
 from nautobot.extras.datasources.git import GitRepository

--- a/projects/nautobot/uoft_nautobot/diffsync/__init__.py
+++ b/projects/nautobot/uoft_nautobot/diffsync/__init__.py
@@ -1,2 +1,41 @@
-from .yaml import SyncFromYAML
-from .bluecat import SyncFromBluecat
+
+
+from nautobot.extras.jobs import Job
+from nautobot_ssot.jobs import DataSource
+from diffsync.enum import DiffSyncFlags
+
+from . import bluecat, yaml
+
+name = "Single Source Of Truth"
+
+class FromBluecat(DataSource, Job):
+    """Data source for Bluecat DDI data"""
+
+    data_source = "Bluecat" # type: ignore
+
+    def __init__(self):
+        super().__init__()
+        self.diffsync_flags = self.diffsync_flags | DiffSyncFlags.SKIP_UNMATCHED_DST
+
+    class Meta: # pylint: disable=missing-class-docstring
+        name = "Bluecat --> Nautobot"
+        description = "Sync data from Bluecat API"
+
+    def load_source_adapter(self):
+        self.source_adapter = bluecat.adapters.Bluecat(job=self)
+
+    def load_target_adapter(self):
+        self.target_adapter = bluecat.adapters.Nautobot(job=self)
+
+class FromYAML(DataSource, Job):
+    """Data source for YAML files"""
+
+    class Meta: # pylint: disable=missing-class-docstring
+        name = "From-YAML"
+        description = "Sync data from YAML file"
+
+    def load_source_adapter(self):
+        self.source_adapter = yaml.adapters.YAML(job=self)
+
+    def load_target_adapter(self):
+        self.target_adapter = yaml.adapters.Nautobot(job=self)

--- a/projects/nautobot/uoft_nautobot/diffsync/bluecat/__init__.py
+++ b/projects/nautobot/uoft_nautobot/diffsync/bluecat/__init__.py
@@ -1,18 +1,1 @@
-from nautobot.extras.jobs import Job
-from nautobot_ssot.jobs import DataSource
-
-from .adapters import Bluecat, Nautobot
-
-
-class SyncFromBluecat(DataSource, Job):
-    """Data source for Bluecat DDI data"""
-
-    class Meta: # pylint: disable=missing-class-docstring
-        name = "From-Bluecat"
-        description = "Sync data from Bluecat API"
-
-    def load_source_adapter(self):
-        self.source_adapter = Bluecat(job=self)
-
-    def load_target_adapter(self):
-        self.target_adapter = Nautobot(job=self)
+from . import adapters

--- a/projects/nautobot/uoft_nautobot/diffsync/bluecat/models.py
+++ b/projects/nautobot/uoft_nautobot/diffsync/bluecat/models.py
@@ -1,47 +1,13 @@
-from glob import glob
 from typing import Literal, Optional, Mapping, TYPE_CHECKING
-from enum import Enum
 from uuid import UUID
 
-from diffsync import DiffSync, DiffSyncModel
+from diffsync import DiffSyncModel
 
-from nautobot.ipam.models import Prefix, Status
-from nautobot.extras.models import CustomField
-from django.contrib.contenttypes.models import ContentType
+from nautobot.ipam.models import Prefix, Status, IPAddress
 
 if TYPE_CHECKING:
-    from .adapters import Bluecat, Nautobot
+    from .adapters import Nautobot
 
-STATUSES = None
-def get_statuses():
-    global STATUSES
-    if STATUSES:
-        return STATUSES
-    STATUSES = {
-        "active": Status.objects.get(slug="active"),
-        "reserved": Status.objects.get(slug="reserved"),
-        "deprecated": Status.objects.get(slug="deprecated"),
-        "container": Status.objects.get(slug="container"),
-    }
-    return STATUSES
-
-BLUECAT_ID_CUSTOM_FIELD_INITIALIZED = False
-
-def ensure_bluecat_id_cf_exists():
-    global BLUECAT_ID_CUSTOM_FIELD_INITIALIZED
-    if BLUECAT_ID_CUSTOM_FIELD_INITIALIZED:
-        return
-    cf = CustomField.objects.get_or_create(
-        name="bluecat_id",
-        defaults={
-            "label": "Bluecat ID",
-            "type": "integer",
-            "description": "The Object ID Bluecat uses to reference this prefix",
-        },
-    )[0]
-    cf.content_types.add(*ContentType.objects.filter(model__in=['prefix', 'ipaddress']))
-    cf.validated_save()
-    BLUECAT_ID_CUSTOM_FIELD_INITIALIZED = True
 
 class Network(DiffSyncModel):
     """
@@ -52,15 +18,14 @@ class Network(DiffSyncModel):
 
     # Metadata about this model
     _modelname = "network"
-    _identifiers = ("id",)
-    _attributes = ("name","prefix", "status")
+    _identifiers = ("prefix",)
+    _attributes = ("name", "status")
 
     # Data type declarations for all identifiers and attributes
 
-    id: int
     prefix: str
     name: str
-    status: Literal['active', 'reserved', 'deprecated', 'container']
+    status: Literal["Active", "Reserved", "Deprecated", "Container"]
     pk: Optional[UUID] = None
 
 
@@ -76,33 +41,90 @@ class NautobotNetwork(Network):
         cls, diffsync: "Nautobot", ids: Mapping, attrs: Mapping
     ) -> Optional["DiffSyncModel"]:
         """Create Prefix object in Nautobot."""
-        status = get_statuses()[attrs["status"]]
+        status = Status.objects.get(name=attrs["status"])
         prefix = Prefix(
-            prefix=attrs["prefix"],
+            prefix=ids["prefix"],
             status=status,
             description=attrs["name"],
         )
-        ensure_bluecat_id_cf_exists()
-        prefix.custom_field_data['bluecat_id'] = ids["id"]
         prefix.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
     def update(self, attrs: Mapping) -> Optional["DiffSyncModel"]:
         """Update Prefix object in Nautobot."""
         prefix = Prefix.objects.get(pk=self.pk)  # type: ignore
-        if attrs.get("description"):
+        if attrs.get("name"):
             prefix.description = attrs["name"]
         if attrs.get("status"):
-            prefix.status = get_statuses()[attrs["status"]]
-        if attrs.get("prefix"):
-            prefix.prefix = attrs["prefix"]
+            prefix.status = Status.objects.get(name=attrs["status"])
         prefix.validated_save()
         return super().update(attrs)
 
-    def delete(self) -> Optional["DiffSyncModel"]:
-        """Delete Prefix object in Nautobot."""
-        if self.diffsync and self.diffsync.job:
-            self.diffsync.job.log_warning(f"Prefix {self.prefix} will be deleted.")
-        prefix = Prefix.objects.get(prefix=self.prefix)
-        prefix.delete()
-        return super().delete()
+    # def delete(self) -> Optional["DiffSyncModel"]:
+    #     """Delete Prefix object in Nautobot."""
+    #     if self.diffsync and self.diffsync.job:
+    #         self.diffsync.job.log_warning(f"Prefix {self.prefix} will be deleted.")
+    #     prefix = Prefix.objects.get(prefix=self.prefix)
+    #     prefix.delete()
+    #     return super().delete()
+
+
+class Address(DiffSyncModel):
+    """
+    Shared data model representing
+    what Bluecat calls an IP Address,
+    and nautobot calls an IPAddress.
+    """
+
+    # Metadata about this model
+    _modelname = "address"
+    _identifiers = ("address",)
+    _attributes = ("name", "status")
+
+    # Data type declarations for all identifiers and attributes
+
+    address: str
+    name: str | None
+    status: Literal["Active", "Reserved", "Deprecated", "DHCP"]
+    pk: Optional[UUID] = None
+    bluecat_id: Optional[int] = None
+
+
+class BluecatAddress(Address):
+    """Data model representing an IPv4Address or IPv6Address in Bluecat."""
+
+
+class NautobotAddress(Address):
+    """Data model representing an IPAddress in nautobot"""
+
+    @classmethod
+    def create(
+        cls, diffsync: "Nautobot", ids: Mapping, attrs: Mapping
+    ) -> Optional["DiffSyncModel"]:
+        """Create IPAddress object in Nautobot."""
+        status = Status.objects.get(name=attrs["status"])
+        address = IPAddress(
+            address=ids["address"],
+            status=status,
+            description=attrs["name"],
+        )
+        address.validated_save()
+        return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
+
+    def update(self, attrs: Mapping) -> Optional["DiffSyncModel"]:
+        """Update IPAddress object in Nautobot."""
+        address = IPAddress.objects.get(pk=self.pk)  # type: ignore
+        if attrs.get("name"):
+            address.description = attrs["name"]
+        if attrs.get("status"):
+            address.status = Status.objects.get(name=attrs["status"])
+        address.validated_save()
+        return super().update(attrs)
+
+    # def delete(self) -> Optional["DiffSyncModel"]:
+    #     """Delete IPAddress object in Nautobot."""
+    #     if self.diffsync and self.diffsync.job:
+    #         self.diffsync.job.log_warning(f"IPAddress {self.address} will be deleted.")
+    #     address = IPAddress.objects.get(address=self.address)
+    #     address.delete()
+    #     return super().delete()

--- a/projects/nautobot/uoft_nautobot/diffsync/yaml/__init__.py
+++ b/projects/nautobot/uoft_nautobot/diffsync/yaml/__init__.py
@@ -1,18 +1,1 @@
-from nautobot.extras.jobs import Job
-from nautobot_ssot.jobs import DataSource
-
-from .adapters import YAML, Nautobot
-
-
-class SyncFromYAML(DataSource, Job):
-    """Data source for YAML files"""
-
-    class Meta: # pylint: disable=missing-class-docstring
-        name = "From-YAML"
-        description = "Sync data from YAML file"
-
-    def load_source_adapter(self):
-        self.source_adapter = YAML(job=self)
-
-    def load_target_adapter(self):
-        self.target_adapter = Nautobot(job=self)
+from . import adapters

--- a/projects/nautobot/uoft_nautobot/dispatcher.py
+++ b/projects/nautobot/uoft_nautobot/dispatcher.py
@@ -1,7 +1,19 @@
-from typing import Optional
 from nornir_nautobot.plugins.tasks.dispatcher.default import NetmikoNautobotNornirDriver
-from netmiko.ssh_dispatcher import register_as
+import netmiko.ssh_dispatcher as ssh_dispatcher
 from netmiko.cisco_base_connection import CiscoBaseConnection
+
+def register_as(name: str):
+    def decorator(cls):
+        ssh_dispatcher.CLASS_MAPPER_BASE[name] = cls
+        ssh_dispatcher.CLASS_MAPPER[f"{name}_ssh"] = cls
+        ssh_dispatcher.platforms = list(ssh_dispatcher.CLASS_MAPPER.keys())
+        ssh_dispatcher.platforms.sort()
+        ssh_dispatcher.platforms_base = list(ssh_dispatcher.CLASS_MAPPER_BASE.keys())
+        ssh_dispatcher.platforms_base.sort()
+        ssh_dispatcher.platforms_str = "\n".join(ssh_dispatcher.platforms_base)
+        ssh_dispatcher.platforms_str = "\n" + ssh_dispatcher.platforms_str
+        return cls
+    return decorator
 
 @register_as("aruba_aoscx")
 class ArubaOSCXSSH(CiscoBaseConnection):

--- a/projects/nautobot/uoft_nautobot/jobs.py
+++ b/projects/nautobot/uoft_nautobot/jobs.py
@@ -1,4 +1,4 @@
-from .diffsync import SyncFromYAML, SyncFromBluecat
+from .diffsync import FromYAML, FromBluecat
 
 
-jobs = [SyncFromYAML, SyncFromBluecat]
+jobs = [FromYAML, FromBluecat]

--- a/projects/scripts/pyproject.toml
+++ b/projects/scripts/pyproject.toml
@@ -35,4 +35,5 @@ path = "pyproject.py"
 
 [tool.hatch.build]
 only-packages = true
+packages = ["uoft_scripts"]
 exclude = ["**/tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,12 @@ license = { text = "MIT" }
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build]
+include = ['conftest.py'] # This is a meta-package, it doesn't need to package ANY files, but hatch requires a file selection -_-
+
 [tool.rye]
 managed = true
 dev-dependencies = [
@@ -55,9 +61,6 @@ dev-dependencies = [
 
 [tool.rye.workspace]
 members = ["projects/*", "custom-forks/*"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dev-dependencies = [
     "pexpect @ git+https://github.com/pexpect/pexpect",
     "lazyasd>=0.1.4",
     "lazy-imports>=0.3.1",
+    "pip>=23.3.1",
+    "pipdeptree>=2.13.1",
     #"macropy @ git+https://github.com/alextremblay/macropy",
 ]
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -171,6 +171,7 @@ pathspec==0.11.2
 pexpect @ git+https://github.com/pexpect/pexpect
 pickleshare==0.7.5
 pillow==10.0.0
+pipdeptree==2.13.1
 platformdirs==3.10.0
 pluggy==1.2.0
 plumbum==1.8.2
@@ -265,4 +266,5 @@ yamlordereddictloader==0.4.0
 yarl==1.9.2
 zipp==3.16.2
 # The following packages are considered to be unsafe in a requirements file:
+pip==23.3.1
 setuptools==68.1.2

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -93,6 +93,7 @@ drf-spectacular==0.26.4
 drf-spectacular-sidecar==2023.8.1
 drf-yasg==1.21.7
 dunamai==1.18.0
+ecdsa==0.18.0
 editables==0.5
 et-xmlfile==1.1.0
 exceptiongroup==1.1.3
@@ -209,6 +210,7 @@ python-box==7.0.1
 python-crontab==3.0.0
 python-dateutil==2.8.2
 python-dotenv==1.0.0
+python-jose==3.3.0
 python-ldap @ https://github.com/uoft-networking/python-ldap/releases/download/latest/python_ldap-3.4.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == "linux" and python_version == "3.10" and platform_machine == "x86_64"
 python3-openid==3.2.0
 pytz==2023.3
@@ -222,6 +224,7 @@ requests==2.31.0
 requests-oauthlib==1.3.1
 rich==13.5.2
 rq==1.15.1
+rsa==4.9
 ruamel-yaml==0.17.32
 ruamel-yaml-clib==0.2.7
 ruff==0.0.285

--- a/requirements.lock
+++ b/requirements.lock
@@ -80,6 +80,7 @@ djangorestframework==3.14.0
 drf-spectacular==0.26.4
 drf-spectacular-sidecar==2023.8.1
 drf-yasg==1.21.7
+ecdsa==0.18.0
 et-xmlfile==1.1.0
 executing==1.2.0
 face==20.1.1
@@ -169,6 +170,7 @@ python-box==7.0.1
 python-crontab==3.0.0
 python-dateutil==2.8.2
 python-dotenv==1.0.0
+python-jose==3.3.0
 python-ldap==3.4.3
 python3-openid==3.2.0
 pytz==2023.3
@@ -180,6 +182,7 @@ requests==2.31.0
 requests-oauthlib==1.3.1
 rich==13.5.2
 rq==1.15.1
+rsa==4.9
 ruamel-yaml==0.17.32
 ruamel-yaml-clib==0.2.7
 rx==1.6.3

--- a/run
+++ b/run
@@ -36,6 +36,7 @@ find_rye
 echo "using rye to install monorepo virtualenv..."
 "$rye_bin" sync --no-lock
 ln -s "$HERE/run" $HERE/.venv/lib/python3.10/site-packages/task_runner.py
+$HERE/run --install-completion-in-virtualenv
 
 run_script "$0" "$@"
 """

--- a/run
+++ b/run
@@ -615,4 +615,5 @@ if __name__ == "__main__":
     )
 
     app = _create_root_app()
+    debug = "--debug" in sys.argv
     app()

--- a/tasks/nautobot.py
+++ b/tasks/nautobot.py
@@ -65,7 +65,13 @@ def start(args: Annotated[List[str] | None, typer.Argument()] = None):
     """start nautobot dev server"""
     if args is None:
         args = []
-    server(["runserver", "--noreload", *args])
+    
+    os.environ["NAUTOBOT_ROOT"] = str(REPO_ROOT / "projects/nautobot/.dev_data")
+    from nautobot.core.runner import runner
+    from nautobot.core.cli import main
+    from unittest.mock import patch
+    with patch("nautobot.core.runner.runner.sys.argv", ["nautobot-server", "runserver", "--noreload", *args]):
+        main()
 
 
 def db_command(cmd: str):

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -174,6 +174,20 @@ def package_peek():
         raise Exception(f"Unknown package type: {package}")
 
 
+def uoft():
+    """run the uoft cli"""
+    from uoft_core import __main__ as cli
+    import sys
+
+    # remove all arguments before "uoft" from sys.argv
+    for arg in sys.argv[:]:
+        if arg == "uoft":
+            break
+        else:
+            sys.argv.remove(arg)
+    cli._add_subcommands()
+    cli.app()
+
 # def lock():
 #     import tomlkit
 #     reqs = []


### PR DESCRIPTION
# Nautobot

Added optional Keycloak SSO integration, while maintaining backwards compatibility with LDAP integration (you can choose which one you want :) )

# Aruba

Re-write cpsec-whitelist tool to make it more efficient and (hopefully) easier to read and understand, also add ability to perform dry-run, printing a log of what would have happened

# Core

minor bogfixes and code improvements

# Dev

Add the ability to run any uoft cli tool inside a debugger using the task runner.

Ex if you want to run `uoft aruba cpsec-allowlist provision /path/to/some/file.csv` inside a debug session, you can simply do:
`./run --debug uoft aruba cpsec-allowlist provision /path/to/some/file.csv`
Note: this doesn't work with the direct subcommands (`uoft-aruba`, `uoft-switchconfig`, etc, only the top-level `uoft` command