### PR TITLE
Improvements to Aruba, Core

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import logging
 from pathlib import Path
 import os
+import sys
 
 from uoft_core.tests import MockFolders
 
@@ -31,6 +32,17 @@ if os.getenv("VSCODE_DEBUGGER"):
     @pytest.hookimpl(tryfirst=True)
     def pytest_internalerror(excinfo):
         raise excinfo.value
+    
+    import logging
+    configured = False
+    for handler in logging.root.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            if handler.stream.name == "<stderr>":
+                configured = True
+                break
+    if not configured:
+        logging.root.setLevel(logging.INFO)
+        logging.root.addHandler(logging.StreamHandler())
 
 
 @pytest.fixture

--- a/projects/aruba/uoft_aruba/api.py
+++ b/projects/aruba/uoft_aruba/api.py
@@ -226,31 +226,31 @@ class ArubaRESTAPIClient:
                 return res["_data"]["ap_group"]
 
             @staticmethod
-            def get_ap_client_blacklist():
+            def get_ap_client_blocklist():
                 res = self.showcommand("show ap blacklist-clients")
                 # In AOS 8.10, the output key was changed from "Blacklisted Clients" to "Client Denylist"
                 return res.get("Blacklisted Clients", res.get("Client Denylist"))
 
             @staticmethod
-            def stm_blacklist_remove(mac_address: str):
+            def stm_blocklist_remove(mac_address: str):
                 return self.post(
                     "stm_blacklist_client_remove", {"client-mac": mac_address}
                 )
 
             @staticmethod
-            def blmgr_blacklist_add(mac_address: str):
+            def blmgr_blocklist_add(mac_address: str):
                 return self.post(
                     "blmgr_blacklist_client_add", {"client-mac": mac_address}
                 )
 
             @staticmethod
-            def blmgr_blacklist_remove(mac_address: str):
+            def blmgr_blocklist_remove(mac_address: str):
                 return self.post(
                     "blmgr_blacklist_client_remove", {"client-mac": mac_address}
                 )
 
             @staticmethod
-            def blmgr_blacklist_purge():
+            def blmgr_blocklist_purge():
                 return self.post("blmgr_blacklist_clients_purge", {})
 
         return WLAN

--- a/projects/aruba/uoft_aruba/cli_commands/station_blocklist.py
+++ b/projects/aruba/uoft_aruba/cli_commands/station_blocklist.py
@@ -1,5 +1,5 @@
 """
-Manage entries in the Station Manager (STM) / Blacklist Manager (BLMGR) blacklist database.
+Manage entries in the Station Manager (STM) / Blocklist Manager (BLMGR) blocklist database.
 """
 
 import json
@@ -12,7 +12,7 @@ app = typer.Typer(  # If run as main create a 'typer.Typer' app instance to run 
     context_settings={"max_content_width": 120, "help_option_names": ["-h", "--help"]},
     no_args_is_help=True,
     help=__doc__,  # Use this module's docstring as the main program help text
-    short_help="Aruba STM Blacklist Management Tools",
+    short_help="Aruba STM Blocklist Management Tools",
     add_completion=False,
 )
 
@@ -20,14 +20,14 @@ app = typer.Typer(  # If run as main create a 'typer.Typer' app instance to run 
 @app.command()
 def get(
     as_json: bool = typer.Option(
-        False, help="Return the list of blacklisted MACs as JSON."
+        False, help="Return the list of blocklisted MACs as JSON."
     )
 ):
-    "Print out a list of all entries in the STM/BLMGR Blacklist"
+    "Print out a list of all entries in the STM/BLMGR Blocklist"
     res = {}
     for c in settings().md_api_connections:
         with c:
-            for entry in c.wlan.get_ap_client_blacklist():
+            for entry in c.wlan.get_ap_client_blocklist():
                 res[entry["STA"]] = entry
 
     if as_json:
@@ -38,21 +38,22 @@ def get(
 
 @app.command()
 def remove(ctx: typer.Context, mac_address: str):
-    "Remove a MAC address from the STM/BLMGR Blacklist"
+    "Remove a MAC address from the STM/BLMGR Blocklist"
     with settings().mm_api_connection as c:
-        c.wlan.blmgr_blacklist_remove(mac_address)
+        c.wlan.blmgr_blocklist_remove(mac_address)
         c.controller.write_memory()
 
-    print(f"Removed {mac_address} from the STM/BLMGR Blacklist")
-    
+    print(f"Removed {mac_address} from the STM/BLMGR Blocklist")
+
+
 @app.command()
 def purge(ctx: typer.Context):
-    "Purge all entries from the STM/BLMGR Blacklist"
+    "Purge all entries from the STM/BLMGR Blocklist"
     with settings().mm_api_connection as c:
-        c.wlan.blmgr_blacklist_purge()
+        c.wlan.blmgr_blocklist_purge()
         c.controller.write_memory()
 
-    print(f"the STM/BLMGR Blacklist has been purged")
+    print("the STM/BLMGR Blocklist has been purged")
 
 
 @app.command()
@@ -60,14 +61,14 @@ def add(
     ctx: typer.Context,
     mac_address: str,
 ):
-    "Add a MAC address to the AP Client Blacklist"
+    "Add a MAC address to the AP Client Blocklist"
     # stm endpoint on individual controllers does not support post operations
     # when those controllers are slaved to a mobility master. we need to use the blmgr endpoint
     # on the mobility master instead
     with settings().mm_api_connection as c:
         c.login()
-        c.wlan.blmgr_blacklist_add(mac_address)
+        c.wlan.blmgr_blocklist_add(mac_address)
         c.controller.write_memory()
         c.logout()
 
-    print("Added {mac_address} to the STM/BLMGR Blacklist")
+    print(f"Added {mac_address} to the STM/BLMGR Blocklist")

--- a/projects/aruba/uoft_aruba/tests/end_to_end_tests.py
+++ b/projects/aruba/uoft_aruba/tests/end_to_end_tests.py
@@ -4,17 +4,17 @@ from .. import batch
 import pytest
 
 
-def _get_blacklist(*controllers):
-    blacklist = []
+def _get_blocklist(*controllers):
+    blocklist = []
     for controller in controllers:
         controller: ArubaRESTAPIClient
-        blacklist += [x["STA"] for x in controller.wlan.get_ap_client_blacklist()]
-    return set(blacklist)
+        blocklist += [x["STA"] for x in controller.wlan.get_ap_client_blocklist()]
+    return set(blocklist)
 
 
 @pytest.mark.end_to_end
 class APITests:
-    def test_blmgr_blacklist(self):
+    def test_blmgr_blocklist(self):
         s = Settings.from_cache()
 
         mm = s.mm_api_connection
@@ -25,12 +25,12 @@ class APITests:
             mm.login()
             md1.login()
             md2.login()
-            mm.wlan.blmgr_blacklist_add("11:11:11:11:11:11")
-            blacklist = _get_blacklist(md1, md2)
-            assert "11:11:11:11:11:11" in blacklist
-            mm.wlan.blmgr_blacklist_remove("11:11:11:11:11:11")
-            blacklist = _get_blacklist(md1, md2)
-            assert "11:11:11:11:11:11" not in blacklist
+            mm.wlan.blmgr_blocklist_add("11:11:11:11:11:11")
+            blocklist = _get_blocklist(md1, md2)
+            assert "11:11:11:11:11:11" in blocklist
+            mm.wlan.blmgr_blocklist_remove("11:11:11:11:11:11")
+            blocklist = _get_blocklist(md1, md2)
+            assert "11:11:11:11:11:11" not in blocklist
         finally:
             mm.logout()
             md1.logout()

--- a/projects/core/README.md
+++ b/projects/core/README.md
@@ -124,7 +124,7 @@ def _debug():
 
 ```
 
-In this example, I'm debugging the uoft_aruba cli tool. If I run the debug selector, enter "uoft_aruba.cli" in the module prompt, and enter "cpsec whitelist provision some_file.csv" in the args prompt, it would be equivalent to running "uoft_aruba cpsec whitelist provision some_file.csv", but inside of a debugger. This would allow me to debug the `uoft_aruba.cpsec_whitelist.provision` function in the same context as when it's run from the command line in production.
+In this example, I'm debugging the uoft_aruba cli tool. If I run the debug selector, enter "uoft_aruba.cli" in the module prompt, and enter "cpsec allowist provision some_file.csv" in the args prompt, it would be equivalent to running "uoft_aruba cpsec allowist provision some_file.csv", but inside of a debugger. This would allow me to debug the `uoft_aruba.cpsec_allowlist.provision` function in the same context as when it's run from the command line in production.
 
 ## `uoft_core.debug_cache`
 I've added a handy little utility to uoft_core which is great for debugging and testing code which has a long startup (Ex code that loads a bunch of data from an API or SSH session and then processes that data. This `debug_cache`function is a decorator you can add to a function which will save the output of that function to disk the first time that function is run, and then reuse that saved output every subsequent time you run your code. 

--- a/projects/core/uoft_core/__init__.py
+++ b/projects/core/uoft_core/__init__.py
@@ -243,7 +243,7 @@ def lst(s: str) -> List[str]:
     return list_
 
 
-def shell(cmd: str, input: str | bytes | None = None) -> str:
+def shell(cmd: str, input_: str | bytes | None = None, cwd: str | Path | None = None) -> str:
     """
     run a shell command, and return its output
 
@@ -253,11 +253,11 @@ def shell(cmd: str, input: str | bytes | None = None) -> str:
         >>> shell("grep -i 'hello'", "Hello world")
         'Hello world'
     """
-    if input is not None and isinstance(input, str):
-        input = input.encode()
+    if input_ is not None and isinstance(input_, bytes):
+        input_ = input_.decode()
     return (
-        run(cmd, shell=True, capture_output=True, check=True, input=input)
-        .stdout.decode()
+        run(cmd, shell=True, capture_output=True, check=True, text=True, input=input_, cwd=cwd)
+        .stdout
         .strip()
     )
 

--- a/projects/core/uoft_core/__init__.py
+++ b/projects/core/uoft_core/__init__.py
@@ -1069,6 +1069,8 @@ S = TypeVar("S", bound="BaseSettings")
 
 
 class BaseSettingsMeta(ModelMetaclass):
+    # This metaclass is responsible for setting the env_prefix attribute on the Config class of any 
+    # subclass of BaseSettings
     def __new__(cls, name, bases, namespace, **kwargs):
         config_class = namespace.get("Config")
         if config_class is None:

--- a/projects/core/uoft_core/__init__.py
+++ b/projects/core/uoft_core/__init__.py
@@ -6,7 +6,7 @@ import logging.handlers
 import os
 import pickle
 import platform
-import re
+import logging
 import sys
 import time
 from shutil import which
@@ -34,7 +34,7 @@ from typing import (
     get_origin,
 )
 
-from loguru import logger
+
 from pydantic import BaseSettings as PydanticBaseSettings, Extra, root_validator
 from pydantic.fields import Field
 import pydantic.types
@@ -52,9 +52,20 @@ if TYPE_CHECKING:
 
 __version__ = version(__package__)
 
-logger.disable(__name__)
-# loguru best practice is for libraries to disable themselves and
-# for cli apps to re-enable logging on the libraries they use
+class CoreLogger(logging.Logger):
+    def trace(self, msg, *args, **kwargs):
+        self.log(5, msg, *args, **kwargs)
+
+def get_logger(name):
+    orig_logger_class = logging.getLoggerClass()
+    logging.setLoggerClass(CoreLogger)
+    logger: CoreLogger = logging.getLogger(name) # type: ignore
+    logging.setLoggerClass(orig_logger_class)
+    return logger
+
+
+logging.addLevelName(5, "TRACE")
+logger = get_logger(__name__)
 
 # region SECTION util functions & classes
 
@@ -339,9 +350,12 @@ def create_or_update_config_file(
     file: Path, obj: dict[str, Any], write_as: Optional[DataFileFormats] = None
 ):
     if file.exists():
+        logger.debug(f"Updating existing config file {file}")
         existing = parse_config_file(file, parse_as=write_as)
         existing.update(obj)
         obj = existing
+    else:
+        logger.debug(f"Creating new config file {file}")
     write_config_file(file, obj, write_as=write_as)
 
 
@@ -366,12 +380,14 @@ class PassPath(PosixPath):
         if self._pass_installed:
             if self._contents is None:
                 try:
+                    logger.debug(f"Running pass command: `{self.command_name}`")
                     self._contents = shell(self.command_name)
                 except CalledProcessError as e:
                     if b'gpg: decryption failed:' in e.stderr:
                         raise e
                     self._contents = ""
             return self._contents
+        logger.debug(f"pass is not installed, skipping {self}")
         return ""
 
     def exists(self) -> bool:
@@ -511,6 +527,7 @@ class InterceptHandler(logging.Handler):
 
     def emit(self, record):
         # Get corresponding Loguru level if it exists
+        from loguru import logger
         try:
             level = logger.level(record.levelname).name
         except ValueError:
@@ -682,7 +699,7 @@ class Util:
         @cached_property
         def files(self):
             res = list(self.files_generator())
-            logger.bind(list=res).trace("Caching list of config files: ")
+            logger.trace(f"Caching list of config files: {res}")
             return res
 
         @property
@@ -826,6 +843,7 @@ class Util:
             self.syslog_format = f"{self.parent.app_name} | {{name}}:{{function}}:{{line}} - {{level.name: ^8}} | {{message}} | Data: {{extra}}"
 
         def add_stderr_sink(self, level="INFO", **kwargs):
+            from loguru import logger
             options = dict(
                 backtrace=False,
                 level=level,
@@ -836,6 +854,7 @@ class Util:
             logger.add(sys.stderr, **options)  # type: ignore
 
         def add_stderr_rich_sink(self, level="INFO", **kwargs):
+            from loguru import logger
             options = dict(
                 backtrace=False,
                 level=level,
@@ -845,6 +864,7 @@ class Util:
             logger.add(self.parent.console.print, **options)  # type: ignore
 
         def add_json_logfile_sink(self, filename=None, level="DEBUG", **kwargs):
+            from loguru import logger
             filename = filename or f"{self.parent.app_name}.log"
             options = dict(
                 level=level,
@@ -858,6 +878,7 @@ class Util:
             logger.add(filename, **options)  # type: ignore
 
         def add_syslog_sink(self, level="DEBUG", syslog_address=None, **kwargs):
+            from loguru import logger
             if platform.system() == "Windows":
                 # syslog configs like level and facility don't apply in windows,
                 # so we set up a basic event log handler instead
@@ -882,6 +903,7 @@ class Util:
             logger.add(handler, **options)  # type: ignore
 
         def add_sentry_sink(self, level="ERROR", **kwargs):
+            from loguru import logger
             try:
                 sentry_dsn = self.parent.config.get_key_or_fail("sentry_dsn")
             except KeyError:
@@ -938,6 +960,7 @@ class Util:
             logger.add(sentry_sink, level=level, **kwargs)
 
         def enable(self):
+            from loguru import logger
             logger.remove()  # remove default handler, if it exists
             logger.enable("")  # enable all logs from all modules
 
@@ -1070,7 +1093,10 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
     def from_cache(cls: Type[S]) -> S:
         # For each subclass of BaseSettings, this method should return an instance of that subclass
         if cls._instance is None:
+            logger.debug(f"Settings(app_name={cls.Config.app_name}): Loading settings")
             cls._instance = cls()
+        else:
+            logger.debug(f"Settings(app_name={cls.Config.app_name}): Settings already loaded")
         cls._instance: S
         return cls._instance
 
@@ -1167,6 +1193,7 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
     @classmethod
     def prompt_for_missing_values(cls, values):
         missing_keys = [key for key in cls.__fields__ if key not in values]
+        logger.debug(f"Settings(app_name={cls.Config.app_name}): Missing keys: {missing_keys}")
 
         # If a BaseSettings subclass appears in the missing_keys list, and that field is marked prompt=False,
         # Then we should source the value from the subclass's from_cache method, and remove the subclass from the missing_keys list
@@ -1181,7 +1208,7 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
             except TypeError:
                 is_model = False
             if field.field_info.extra.get("prompt", True) is False:
-
+                logger.debug(f"Settings(app_name={cls.Config.app_name}): Prompting disabled for field {key}")
                 if is_model:
                     values[key] = type_.from_cache()
                 
@@ -1192,16 +1219,19 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
 
         if not missing_keys:
             # Everything's present and accounted for. nothing to do here
+            logger.debug(f"Settings(app_name={cls.Config.app_name}): No missing keys remaining to prompt for")
             return values
 
         if not cls.Config.prompt_on_missing_values:
             # interactively prompting for values is disabled on this subclass
             # Return values as is and let pydantic report validation errors on missing fields
+            logger.debug(f"Settings(app_name={cls.Config.app_name}): Prompting disabled for missing values")
             return values
 
         if not sys.stdout.isatty():
             # We're not in a terminal.  We can't prompt for input.
             # Return values as is and let pydantic report validation errors on missing fields
+            logger.debug(f"Settings(app_name={cls.Config.app_name}): Not in a terminal. Skipping interactive prompt for missing values")
             return values
 
         # We're in a terminal and we're missing some values.
@@ -1225,6 +1255,7 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
         for file_path, file in cls._util().config.files:
             if file in {File.writable, File.creatable}:
                 save_targets.append(str(file_path))
+        logger.debug(f"Settings(app_name={cls.__config__.app_name}): Save targets: {save_targets}")
 
         # prompt user to select a save target
         p = cls._prompt()
@@ -1277,13 +1308,16 @@ class BaseSettings(PydanticBaseSettings, metaclass=BaseSettingsMeta):
                         if not text:
                             # if pass is not installed, or if the pass entry doesn't exist, that's not necessarily an error.
                             continue
+                        logger.debug(f"Attempting to parse TOML data from {path}")
                         res.update(toml.loads(text))
+                        logger.info(f"Loaded settings from {path}")
                     except toml.TOMLDecodeError as e:
                         # at this point, we can be sure that pass is installed, and the user did create a pass entry,
                         # but the entry is not valid TOML. This case IS an error and should be bubbled up to the user.
                         raise UofTCoreError(
                             f"Error parsing data returned from `{path.command_name}`. expected a TOML document, but failed parsing as TOML: {e.args}"
                         ) from e
+                    logger.debug(f"Successfully loaded settings from {path}")
                 return res
 
             return settings_from_pass

--- a/projects/core/uoft_core/__init__.py
+++ b/projects/core/uoft_core/__init__.py
@@ -360,7 +360,7 @@ def create_or_update_config_file(
 
 
 class PassPath(PosixPath):
-    """An abstract path representing an entry in the pass password store"""
+    """An abstract path representing an entry in the `pass` password store"""
 
     _pass_installed: bool
     _contents: str | None
@@ -383,8 +383,10 @@ class PassPath(PosixPath):
                     logger.debug(f"Running pass command: `{self.command_name}`")
                     self._contents = shell(self.command_name)
                 except CalledProcessError as e:
-                    if b'gpg: decryption failed:' in e.stderr:
+                    if 'gpg: decryption failed:' in e.stderr:
                         raise e
+                    if e.returncode == 1:
+                        logger.debug(f"Password-store entry {self} does not exist, skipping")
                     self._contents = ""
             return self._contents
         logger.debug(f"pass is not installed, skipping {self}")
@@ -409,7 +411,7 @@ class PassPath(PosixPath):
         self, data: str, encoding: str | None = None, errors: str | None = None
     ) -> None:
         if self._pass_installed:
-            shell(f"pass insert -m {self}", input=data)
+            shell(f"pass insert -m {self}", input_=data)
             self._contents = data
         else:
             raise UofTCoreError(

--- a/projects/core/uoft_core/__main__.py
+++ b/projects/core/uoft_core/__main__.py
@@ -47,9 +47,8 @@ def callback(
         log_level = "DEBUG"
     if trace:
         log_level = "TRACE"
-    util.logging.enable()
-    util.logging.add_stderr_rich_sink(log_level)
-    util.logging.add_syslog_sink()
+    import logging
+    logging.basicConfig(level=log_level, format="%(levelname)s: %(message)s", stream=sys.stderr)
 
 
 # [[[cog

--- a/projects/core/uoft_core/__main__.py
+++ b/projects/core/uoft_core/__main__.py
@@ -64,7 +64,6 @@ ALL_PROJECTS = [
     "ssh",
     "scripts",
     "switchconfig",
-    "core",
 ]
 # [[[end]]]
 
@@ -88,9 +87,16 @@ def _add_subcommands() -> tuple[set[str], set[str]]:
             # if the module isn't installed locally, doesn't have a cli.py,
             # or if it doesn't have an app object,
             # look for it on PATH and add a virtual subcommand for it
-            if ext := which(f"uoft-{p}"):
+            ext = which(f"uoft-{p}")
+            if ext:
+                name = ext
                 external_subcommands.add(p)
-                app.command(p)(lambda: os.execve(ext, [f"uoft-{p}"] + sys.argv[2:]))  # type: ignore
+
+                # I think a typer update broke my lambda...
+                # seems to require an actual function now
+                @app.command(p)
+                def _():
+                    os.execv(name, [f"uoft-{p}"] + sys.argv[2:])
 
     return internal_subcommands, external_subcommands
 
@@ -153,6 +159,7 @@ def cli():
     except KeyboardInterrupt:
         print("Aborted!")
         sys.exit()
+        
 
 
 if __name__ == "__main__":

--- a/projects/core/uoft_core/prompt.py
+++ b/projects/core/uoft_core/prompt.py
@@ -110,6 +110,7 @@ class Prompt:
         default_value: str | None = None,
         completer_opts: dict | None = None,
         fuzzy_search: bool = False,
+        generate_rprompt: bool = True,
         **kwargs,
     ) -> str:
         validator = Validator.from_callable(
@@ -121,10 +122,11 @@ class Prompt:
         completer = WordCompleter(list(choices), **completer_opts)
         if fuzzy_search:
             completer = FuzzyCompleter(completer)
+        if generate_rprompt:
+            kwargs["rprompt"] = HTML(f"Valid options are: <b>{', '.join(choices)}</b>")
         opts = dict(
             completer=completer,
             complete_while_typing=True,
-            rprompt=HTML(f"Valid options are: <b>{', '.join(choices)}</b>"),
             validator=validator,
         )
         opts.update(kwargs)

--- a/projects/core/uoft_core/types.py
+++ b/projects/core/uoft_core/types.py
@@ -4,7 +4,7 @@ from typing import Literal, Any
 from pathlib import Path
 from pydantic import BaseModel, Field
 from pydantic.types import SecretStr as SecretStrBase, FilePath, DirectoryPath
-from ._vendor.netaddr import IPNetwork, IPAddress
+from ._vendor.netaddr import IPNetwork as IPNetworkBase, IPAddress as IPAddressBase
 
 
 _json_default = json.JSONEncoder.default
@@ -28,7 +28,19 @@ json.JSONEncoder.default = _custom_json_default_encoder
 BaseModel.__json_encode__ = BaseModel.dict # type: ignore
 
 
-class IPv4Address(IPAddress):
+class IPAddress(IPAddressBase):
+    @classmethod
+    def __get_validators__(cls):
+        def validator(val: Any) -> "IPAddress":
+            nv = cls(val)
+            if nv.version == 4:
+                return nv.ipv4()  # type: ignore
+            return nv.ipv6() # type: ignore
+
+        yield validator
+
+
+class IPv4Address(IPAddressBase):
     @classmethod
     def __get_validators__(cls):
         def validator(val: Any) -> "IPv4Address":
@@ -37,7 +49,7 @@ class IPv4Address(IPAddress):
         yield validator
 
 
-class IPv6Address(IPAddress):
+class IPv6Address(IPAddressBase):
     @classmethod
     def __get_validators__(cls):
         def validator(val: Any) -> "IPv6Address":
@@ -46,7 +58,19 @@ class IPv6Address(IPAddress):
         yield validator
 
 
-class IPv4Network(IPNetwork):
+class IPNetwork(IPNetworkBase):
+    @classmethod
+    def __get_validators__(cls):
+        def validator(val: Any) -> "IPNetwork":
+            nv = cls(val)
+            if nv.version == 4:
+                return nv.ipv4()  # type: ignore
+            return nv.ipv6() # type: ignore
+
+        yield validator
+
+
+class IPv4Network(IPNetworkBase):
     @classmethod
     def __get_validators__(cls):
         def validator(val: Any) -> "IPv4Network":
@@ -55,7 +79,7 @@ class IPv4Network(IPNetwork):
         yield validator
 
 
-class IPv6Network(IPNetwork):
+class IPv6Network(IPNetworkBase):
     @classmethod
     def __get_validators__(cls):
         def validator(val: Any) -> "IPv6Network":
@@ -109,5 +133,9 @@ __all__ = (
     "DirectoryPath",
     "StrEnum",
     "IPNetwork",
+    "IPv4Network",
+    "IPv6Network",
     "IPAddress",
+    "IPv4Address",
+    "IPv6Address",
 )

--- a/projects/nautobot/uoft_nautobot/api/views.py
+++ b/projects/nautobot/uoft_nautobot/api/views.py
@@ -86,7 +86,7 @@ class ArubaBlocklistView(APIView):
     )
     def get(self, request, format=None):
         """
-        Get the current aggregated WiFi authentication block list (aka 'stm blacklist')
+        Get the current aggregated WiFi authentication block list (aka 'stm blocklist')
         from the aruba controllers
 
         Example:
@@ -118,7 +118,12 @@ class ArubaBlocklistView(APIView):
         res = {}
         for c in self.controllers:
             with c as conn:
-                res.update({entry['STA']: entry for entry in conn.wlan.get_ap_client_blacklist()})
+                res.update(
+                    {
+                        entry["STA"]: entry
+                        for entry in conn.wlan.get_ap_client_blocklist()
+                    }
+                )
         return Response(list(res.values()))
 
     @extend_schema(
@@ -144,7 +149,7 @@ class ArubaBlocklistView(APIView):
     )
     def delete(self, request, format=None):
         """
-        Remove a mac address from the WiFi authentication block list (aka 'stm blacklist')
+        Remove a mac address from the WiFi authentication block list (aka 'stm blocklist')
         of the aruba controllers.
         Requests on this endpoint must include a JSON payload with a 'mac-address'
         key whose value matches the regex pattern '^(([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2})$'.
@@ -165,7 +170,7 @@ class ArubaBlocklistView(APIView):
 
         # Now we can go ahead and delete the mac-address
         with self.mobility_master as conn:
-            conn.wlan.blmgr_blacklist_remove(mac)
+            conn.wlan.blmgr_blocklist_remove(mac)
 
         res = {
             "detail": f"mac address '{mac}' has been removed from the aruba stm blocklist"

--- a/projects/scripts/pyproject.toml
+++ b/projects/scripts/pyproject.toml
@@ -20,8 +20,6 @@ dynamic = ["version"]
 
 [project.scripts]
 uoft-scripts = "uoft_scripts.cli:cli"
-uoft_scripts = "uoft_scripts.cli:deprecated"
-"utsc.scripts" = "uoft_scripts.cli:deprecated"
 
 [build-system]
 requires = ["hatchling >= 1.6.0", "setuptools_scm"]

--- a/projects/scripts/uoft_scripts/cli.py
+++ b/projects/scripts/uoft_scripts/cli.py
@@ -50,9 +50,8 @@ def callback(
         log_level = "DEBUG"
     if trace:
         log_level = "TRACE"
-    config.util.logging.enable()
-    config.util.logging.add_stderr_rich_sink(log_level)
-    config.util.logging.add_syslog_sink()
+    import logging
+    logging.basicConfig(level=log_level, format="%(levelname)s: %(message)s", stream=sys.stderr)
 
 
 def cli():
@@ -62,10 +61,6 @@ def cli():
     except KeyboardInterrupt:
         print("Aborted!")
         sys.exit()
-    except Exception as e:  # pylint: disable=broad-except
-        # wrap exceptions so that only the message is printed to stderr, stacktrace printed to log
-        logger.error(e)
-        logger.debug(traceback.format_exc())
 
 
 def deprecated():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev-dependencies = [
     "python-ldap @ https://github.com/uoft-networking/python-ldap/releases/download/latest/python_ldap-3.4.3-cp310-cp310-macosx_10_9_universal2.whl ; sys_platform == 'darwin' and python_version == '3.10'",
     "copier-templates-extensions>=0.3.0",
     "hatchling>=1.18.0",
-    "scalene>=1.5.31.1",
+    "scalene>=1.5.38",
     "mypy>=1.6",
     "coconut[watch]>=3.0.3",
     "shellingham>=1.5.4",


### PR DESCRIPTION
# Aruba
## Rename all API endpoints, API class methods, and CLI commands referencing blacklist/whitelist to blocklist/allowlist

Apart from a few outliers remaining withing the Aruba REST API, most references to `blacklist` or `whitelist` have been renamed to less racially charged terms, and we're more than happy to follow suit! #:tada: 

# Core

## `shell` function

the `shell` function has always tried to take in and return strings, rther than `bytes` objects. Now, it correctly handles more edge cases and can support feeding in strings to a shell command's `stdin` stream

## `uoft` cli command
bugfix re-enabled cli autocomplete for the `uoft` umbrall cli command which wraps all `uoft-` prefixed commands

## logging
This PR is the first stwep toward transitioning away from using `luguru` as our stnadard logging library and towards a healthy integration between the standard library's `logging` module and using `rich` to handle log output ot the user.

what this means currently is that we can start logging everything we're doing at every level of our programs, and gradually add richer user accsss / integration to those logs

## Bugfixes

An assortment of minor bugfixes, too small to summarize